### PR TITLE
Support Model.create() via the new Error middleware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## v5.0.0
+
+### Breaking changes
+
+* Beautifies the errors using an error middleware instead of overriding
+the `#save()` method. **Only supports Mongoose 4.5.0 and onwards.**
+
+### New features
+
+* Also works on all other ways of saving models, not only `#save()`
+(including `Model.create()`).
+
 ## v4.0.0
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
 * Beautifies the errors using an error middleware instead of overriding
 the `#save()` method. **Only supports Mongoose 4.5.0 and onwards.**
 
+* Because `#save()` is not overriden anymore, the `beautifyUnique` option
+is now ignored. To remove the beautifying behavior, remove the plugin.
+
 ### New features
 
 * Also works on all other ways of saving models, not only `#save()`

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Duplicates will be reported with this kind of error:
 This is not the same kind of error as normal
 [Validation](http://mongoosejs.com/docs/validation.html) errors, so you need
 to handle that as a special case―and special cases allow room for bugs.
-This plugin solves this problem by converting driver-level duplicate errors
+This plugin solves this problem by turning driver-level duplicate errors
 (E11000 and E11001) into regular Validation errors.
 
 ```json
@@ -65,6 +65,21 @@ This plugin solves this problem by converting driver-level duplicate errors
 ```sh
 npm install --save mongoose-beautiful-unique-validation
 ```
+
+### Supported versions of Mongoose
+
+The 5.0.0 versions of this module only support
+Mongoose 4.5.0 and upper.
+If you need to use previous versions of
+Mongoose, use the 4.0.0 versions.
+
+### Supported versions of Node
+
+The latest version of this module supports Node.js
+version `6.*`, `5.*`, `4.*`, `0.12.*` and `0.10.*`.
+If you find a bug while using one of these versions, you can
+[fill a bug report](https://github.com/matteodelabre/mongoose-beautiful-unique-validation/issues/new)
+and we will take care of it as soon as possible!
 
 ## Example
 
@@ -108,7 +123,8 @@ admin2.save()
 ## Usage
 
 Schemata that will produce beautified errors need to be plugged
-in with this module using the `.plugin()` method.
+in with this module using the `.plugin()` method. You can also
+use it as a [global plugin.](http://mongoosejs.com/docs/plugins.html#global)
 
 **You need to plug in this module after declaring all
 indexes on the schema, otherwise they will not be beautified.**
@@ -117,31 +133,6 @@ By default, the `ValidatorError` message will be
 `Validator failed for path xxx with value xxx`.
 If you want to override it, add your custom message in the `unique`
 field (instead of `true`), during the schema's creation.
-
-This plugin overrides the `.save()` method to add beautifying
-behavior. If you do not want it, you can pass the
-`beautifyUnique` option to `false`:
-
-```js
-doc.save({
-    beautifyUnique: false
-}).then(() => {
-    // stuff
-});
-```
-
-## Supported versions
-
-The latest version of this module supports all of the following Node.js versions.
-If you find a bug while using one of these versions, you can
-[fill a bug report](https://github.com/matteodelabre/mongoose-beautiful-unique-validation/issues/new)
-and we will take care of it as soon as possible!
-
-* 6.*
-* 5.*
-* 4.*
-* 0.12.*
-* 0.10.*
 
 ## License
 

--- a/package.json
+++ b/package.json
@@ -27,10 +27,13 @@
     "url": "https://github.com/matteodelabre"
   },
   "dependencies": {
-    "mongoose": "^4.4.7",
     "promise": "^7.1.1"
   },
+  "peerDependencies": {
+    "mongoose": ">=4.5"
+  },
   "devDependencies": {
+    "mongoose": "^4.5.9",
     "kerberos": "0.0.19",
     "tap-spec": "^4.1.1",
     "tape": "^4.5.1"

--- a/tests/save.js
+++ b/tests/save.js
@@ -6,55 +6,7 @@ var Schema = mongoose.Schema;
 var assertDuplicateFailure = require('./utils').assertDuplicateFailure;
 var beautifulValidation = require('../');
 
-test('should save documents', function (assert) {
-    var NormalSaveSchema = new Schema({
-        name: String
-    });
-
-    NormalSaveSchema.plugin(beautifulValidation);
-
-    var NormalSave = mongoose.model('NormalSave', NormalSaveSchema);
-    var instance = new NormalSave({
-        name: 'Test for Normal Save'
-    });
-
-    instance.save(function (saveError) {
-        assert.error(saveError, 'should save an instance successfully');
-
-        NormalSave.find({
-            name: 'Test for Normal Save'
-        }, function (findError, result) {
-            assert.error(findError, 'should find back the saved instance');
-            assert.looseEqual(result[0].name, 'Test for Normal Save', 'should keep the document intact');
-            assert.end();
-        });
-    });
-});
-
-test('should provide a promise', function (assert) {
-    var PromiseSaveSchema = new Schema({
-        name: String
-    });
-
-    PromiseSaveSchema.plugin(beautifulValidation);
-
-    var PromiseSave = mongoose.model('PromiseSave', PromiseSaveSchema);
-    var instance = new PromiseSave({
-        name: 'Test for Promise Save'
-    });
-
-    instance.save().then(function () {
-        PromiseSave.find({
-            name: 'Test for Promise Save'
-        }, function (findError, result) {
-            assert.error(findError, 'should find back the saved instance');
-            assert.looseEqual(result[0].name, 'Test for Promise Save', 'should keep the document intact');
-            assert.end();
-        });
-    }).catch(function (error) {
-        assert.error(error, 'should save an instance successfully');
-    });
-});
+mongoose.plugin(beautifulValidation);
 
 test('should report duplicates', function (assert) {
     var DuplicateSchema = new Schema({
@@ -64,11 +16,27 @@ test('should report duplicates', function (assert) {
         }
     });
 
-    DuplicateSchema.plugin(beautifulValidation);
     var Duplicate = mongoose.model('Duplicate', DuplicateSchema);
 
     assertDuplicateFailure(assert, Duplicate, {
         address: '123 Fake St.'
+    });
+});
+
+test('should report duplicates with Model.create()', function (assert) {
+    var CreateSchema = new Schema({
+        address: {
+            type: String,
+            unique: true
+        }
+    });
+
+    var Create = mongoose.model('Create', CreateSchema);
+
+    assertDuplicateFailure(assert, Create, {
+        address: '123 Fake St.'
+    }, undefined, function (doc) {
+        return Create.create(doc);
     });
 });
 
@@ -80,7 +48,6 @@ test('should report duplicates on fields containing spaces', function (assert) {
         }
     });
 
-    SpacesSchema.plugin(beautifulValidation);
     var Spaces = mongoose.model('Spaces', SpacesSchema);
 
     assertDuplicateFailure(assert, Spaces, {
@@ -101,7 +68,6 @@ test('should report duplicates on compound indexes', function (assert) {
         unique: true
     });
 
-    CompoundSchema.plugin(beautifulValidation);
     var Compound = mongoose.model('Compound', CompoundSchema);
 
     assertDuplicateFailure(assert, Compound, {
@@ -118,7 +84,6 @@ test('should report duplicates with the custom validation message', function (as
         }
     });
 
-    MessageSchema.plugin(beautifulValidation);
     var Message = mongoose.model('Message', MessageSchema);
 
     assertDuplicateFailure(assert, Message, {
@@ -139,7 +104,6 @@ test('should report duplicates on compound indexes with the custom validation me
         unique: 'yet another custom message'
     });
 
-    CompoundMessageSchema.plugin(beautifulValidation);
     var CompoundMessage = mongoose.model('CompoundMessage', CompoundMessageSchema);
 
     assertDuplicateFailure(assert, CompoundMessage, {
@@ -171,7 +135,6 @@ test('should report duplicates on any mongoose type', function (assert) {
         unique: true
     });
 
-    AnyTypeSchema.plugin(beautifulValidation);
     var AnyType = mongoose.model('AnyType', AnyTypeSchema);
 
     assertDuplicateFailure(assert, AnyType, {

--- a/tests/save.js
+++ b/tests/save.js
@@ -18,7 +18,9 @@ test('should report duplicates', function (assert) {
 
     var Duplicate = mongoose.model('Duplicate', DuplicateSchema);
 
-    assertDuplicateFailure(assert, Duplicate, {
+    assertDuplicateFailure(assert, function (doc) {
+        return new Duplicate(doc).save();
+    }, {
         address: '123 Fake St.'
     });
 });
@@ -33,10 +35,10 @@ test('should report duplicates with Model.create()', function (assert) {
 
     var Create = mongoose.model('Create', CreateSchema);
 
-    assertDuplicateFailure(assert, Create, {
-        address: '123 Fake St.'
-    }, undefined, function (doc) {
+    assertDuplicateFailure(assert, function (doc) {
         return Create.create(doc);
+    }, {
+        address: '123 Fake St.'
     });
 });
 
@@ -50,7 +52,9 @@ test('should report duplicates on fields containing spaces', function (assert) {
 
     var Spaces = mongoose.model('Spaces', SpacesSchema);
 
-    assertDuplicateFailure(assert, Spaces, {
+    assertDuplicateFailure(assert, function (doc) {
+        return new Spaces(doc).save();
+    }, {
         'display name': 'Testing display names'
     });
 });
@@ -70,7 +74,9 @@ test('should report duplicates on compound indexes', function (assert) {
 
     var Compound = mongoose.model('Compound', CompoundSchema);
 
-    assertDuplicateFailure(assert, Compound, {
+    assertDuplicateFailure(assert, function (doc) {
+        return new Compound(doc).save();
+    }, {
         name: 'John Doe',
         age: 42
     });
@@ -86,7 +92,9 @@ test('should report duplicates with the custom validation message', function (as
 
     var Message = mongoose.model('Message', MessageSchema);
 
-    assertDuplicateFailure(assert, Message, {
+    assertDuplicateFailure(assert, function (doc) {
+        return new Message(doc).save();
+    }, {
         address: '123 Fake St.'
     }, 'this is our custom message!');
 });
@@ -106,7 +114,9 @@ test('should report duplicates on compound indexes with the custom validation me
 
     var CompoundMessage = mongoose.model('CompoundMessage', CompoundMessageSchema);
 
-    assertDuplicateFailure(assert, CompoundMessage, {
+    assertDuplicateFailure(assert, function (doc) {
+        return new CompoundMessage(doc).save();
+    }, {
         name: 'John Doe',
         age: 42
     }, 'yet another custom message');
@@ -137,7 +147,9 @@ test('should report duplicates on any mongoose type', function (assert) {
 
     var AnyType = mongoose.model('AnyType', AnyTypeSchema);
 
-    assertDuplicateFailure(assert, AnyType, {
+    assertDuplicateFailure(assert, function (doc) {
+        return new AnyType(doc).save();
+    }, {
         name: 'test',
         group: new mongoose.Types.ObjectId,
         age: 42,

--- a/tests/utils.js
+++ b/tests/utils.js
@@ -13,14 +13,16 @@ function wait(time) {
     });
 }
 
-function assertDuplicateFailure(assert, Model, doc, message, creator) {
-    // by default, we create the models using "new Model()"
-    if (typeof creator !== 'function') {
-        creator = function (args) {
-            return new Model(args).save();
-        };
-    }
-
+/**
+ * Assert that saving the given document twice
+ * produces a beautified error
+ *
+ * @param {Object} assert Tape assertion object
+ * @param {function} creator Callback to create a document
+ * @param {Object} doc The document to use
+ * @param {string} [message] Also check that the given message is passed over
+ */
+function assertDuplicateFailure(assert, creator, doc, message) {
     // save the first instance
     creator(doc).then(function () {
         // ensure the unique index is rebuilt


### PR DESCRIPTION
Move the processing of errors to an Error middleware instead of overriding the `instance#save()` method so that the beautifying also works on `Model.create`.