### PR TITLE
Add error code and array of duplicates in beautified error

### DIFF
--- a/index.js
+++ b/index.js
@@ -99,6 +99,8 @@ function beautify(error, doc, messages) {
         var beautifiedError = new MongooseError.ValidationError();
 
         beautifiedError.errors = suberrors;
+        beautifiedError.code = error.code;
+        beautifiedError.fields = Object.keys(suberrors);
         return beautifiedError;
     });
 }


### PR DESCRIPTION
It would be easier to have the error code (E11000 or E11001) in the beautified error JSON, as well, an array of duplicates fields right away. In my Express App, in every Insert or update I try to catch mongoose errors. If it's a duplicate error, I have to give the duplicate fields in the response, otherwise, I throw a 500 error and log de request. Here's a beautified error example with the changes:

````
{
	"errors": {
		"email": {
			"message": "Validator failed for path `email` with value `user@email.com`",
			"name": "ValidatorError",
			"properties": {
				"type": "Duplicate value",
				"path": "email",
				"value": "user@email.com"
			},
			"kind": "Duplicate value",
			"path": "email",
			"value": "user@email.com"
		}
	},
	"message": "Validation failed",
	"name": "ValidationError",
	"code": 11000,
	"fields": [
		"email"
	]
}

````