### PR TITLE
Avoid throwing a global error, instead transmit it to the middleware

### DIFF
--- a/index.js
+++ b/index.js
@@ -224,16 +224,13 @@ module.exports = function (schema, options) {
             beautify(
                 error, collection, values,
                 messages, options.defaultMessage
-            )
-                .then(next)
-                .catch(function (beautifyError) {
-                    setTimeout(function () {
-                        throw new Error(
-                            'mongoose-beautiful-unique-validation error: '
-                            + beautifyError.stack
-                        );
-                    });
-                });
+            ).then(next, function(beautifyError) {
+                var unknownError = new Error(
+                  'mongoose-beautiful-unique-validation error'
+                );
+              unknownError.stack += '\ncaused by: ' + beautifyError.stack;
+                next(error);
+              });
         } else {
             // Pass over other errors
             next(error);

--- a/index.js
+++ b/index.js
@@ -224,13 +224,13 @@ module.exports = function (schema, options) {
             beautify(
                 error, collection, values,
                 messages, options.defaultMessage
-            ).then(next, function(beautifyError) {
+            ).then(next, function (beautifyError) {
                 var unknownError = new Error(
-                  'mongoose-beautiful-unique-validation error'
+                    'mongoose-beautiful-unique-validation'
                 );
-              unknownError.stack += '\ncaused by: ' + beautifyError.stack;
+                unknownError.stack += '\ncaused by: ' + beautifyError.stack;
                 next(error);
-              });
+            });
         } else {
             // Pass over other errors
             next(error);


### PR DESCRIPTION
Using setTimeout to transfer middleware error leads to uncontrolled request return and instability