### PR TITLE
fix: add hook for 'updateOne'

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,5 +242,6 @@ module.exports = function (schema, options) {
 
     schema.post('save', postHook);
     schema.post('update', postHook);
+    schema.post('updateOne', postHook);
     schema.post('findOneAndUpdate', postHook);
 };


### PR DESCRIPTION
at first, thanks for your open source code, We update the data using the updateOne method. Unique validation did not work at this time. Looking at the reasons, we found that the update method works, but not in updateOne. So I added updateOne hook. Please take a look.